### PR TITLE
Changed memory device file from /dev/mem to /dev/gpiomem

### DIFF
--- a/src/gpio.c
+++ b/src/gpio.c
@@ -20,8 +20,8 @@ void pioInit(gpio_registers* registers) {
   void *reg_map;
   volatile unsigned int *gpio;
 
-  if ((mem_fd = open("/dev/mem", O_RDWR|O_SYNC) ) < 0) {
-    printf("Error: cannot open /dev/mem \n");
+  if ((mem_fd = open("/dev/gpiomem", O_RDWR|O_SYNC) ) < 0) {
+    printf("Error: cannot open /dev/gpiomem \n");
     exit(-1);
   }
 
@@ -31,7 +31,7 @@ void pioInit(gpio_registers* registers) {
     PROT_READ|PROT_WRITE,
     MAP_SHARED,
     mem_fd,
-    GPIO_BASE);
+    GPIOMEM_BASE);
 
   if (reg_map == MAP_FAILED) {
     printf("GPIO memory map failed: error %ld\n", (long) reg_map);

--- a/src/gpio.h
+++ b/src/gpio.h
@@ -22,6 +22,7 @@
 // Physical addresses
 #define BCM2837_PERIPHERAL_BASE   0x3F000000
 #define GPIO_BASE                 (BCM2837_PERIPHERAL_BASE + 0x200000)
+#define GPIOMEM_BASE              0
 #define SYSTIME_BASE              (BCM2837_PERIPHERAL_BASE + 0x003000)
 #define BLOCK_SIZE                (4 * 1024)
 


### PR DESCRIPTION
This PR changes the device file used by the memory map from `/dev/mem` to `/dev/gpiomem`, which is more secure.