### PR TITLE
Changed build Docker container tag convention to use Git commit hash

### DIFF
--- a/ci/build/Makefile
+++ b/ci/build/Makefile
@@ -1,0 +1,20 @@
+# Builds and pushes the rpi-micromanager Docker build images.
+#
+# Based on:
+# https://container-solutions.com/tagging-docker-images-the-right-way/
+#
+# Kyle M. Douglass, 2018
+# kyle.m.douglass@gmail.com
+#
+
+NAME   := kmdouglass/rpi-micromanager
+TAG    := $$(git log -1 --pretty=%H)
+IMG    := ${NAME}:build-${TAG}
+LATEST := ${NAME}:build
+
+build:
+	@docker build -t ${IMG} .
+	@docker tag ${IMG} ${LATEST}
+
+push:
+	@docker push ${NAME}

--- a/ci/build/README.md
+++ b/ci/build/README.md
@@ -90,14 +90,13 @@ You can push the resulting image to your own Dockerhub registry by
 first retagging it.
 
 ```
-$ docker tag kmdouglass/rpi-micromanager:build-YYYYMMDD TARGET_IMAGE
+$ docker tag kmdouglass/rpi-micromanager:build TARGET_IMAGE
 $ docker push TARGET_IMAGE
 ```
 
-where `YYYYMMDD` is the year-month-day that the image definition is
-created on. Note that naming conventions for `TARGET_IMAGE` follow the
-format `USER_NAME/IMAGE_NAME:TAG` where `USER_NAME` is your Dockerhub
+Note that naming conventions for `TARGET_IMAGE` follow the format
+`USER_NAME/IMAGE_NAME:TAG` where `USER_NAME` is your Dockerhub
 username and `:TAG` is optional.
 
-After pushing the new image, you will need to update the
-`docker-compose.yml` file to use it.
+After pushing the new image, you will need to change the
+`docker-compose.yml` file to point towards your own image.

--- a/ci/build/docker-compose.yml
+++ b/ci/build/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   rpi-build:
     build: .
-    image: kmdouglass/rpi-micromanager:build-20181007
+    image: kmdouglass/rpi-micromanager:build
     # .ccache directory must be relative to user home in Travis-CI
     volumes:
       - /opt/rpi-micromanager:/micro-manager/src


### PR DESCRIPTION
- Two identical images are created with a call to `make build push`; one has the `build` tag and the other has the Git commit hash.
- The `build` tag always points to the most recently built image; the image with the Git commit hash remains unchanged once it is created.